### PR TITLE
Integrating Thermal SDK for DJI Cameras

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ A python package for decoding and common processing for thermographs / thermogra
     - **Linux:** Run command `sudo apt-get install exiftool`
     - **Windows:** Download binary from https://exiftool.org/
 2. This tool also requires you to have Python 3+ installed. You can install it from the official website (https://www.python.org/downloads/)
-3. DJI-encoded images need folder containing executable files present in the same directory as the python file which imports the thermal_base package. Download the zip file from [here](https://dtpl-ai-public.s3.ap-south-1.amazonaws.com/Thermal_Image_Analysis/DJI_SDK/dji_executables.zip) and extract the contents to the location of your python file that uses the `thermal_base` package such that the extracted folder `dji_executables` has 2 subfolders named `linux` and `windows` directly inside of it.
-4. Install this package with `python3 -m pip install git+https://github.com/detecttechnologies/thermal_base.git@main`
+3. Install this package with `python3 -m pip install git+https://github.com/detecttechnologies/thermal_base.git@main`
 
 ## Usage
 Import and use the package as follows:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A python package for decoding and common processing for thermographs / thermogra
     - **Linux:** Run command `sudo apt-get install exiftool`
     - **Windows:** Download binary from https://exiftool.org/
 2. This tool also requires you to have Python 3+ installed. You can install it from the official website (https://www.python.org/downloads/)
-2. Install this package with `python3 -m pip install git+https://github.com/detecttechnologies/thermal_base.git@main`
+3. DJI-encoded images need folder containing executable files present in the same directory as the python file which imports the thermal_base package. Download the zip file from [here](https://dtpl-ai-public.s3.ap-south-1.amazonaws.com/Thermal_Image_Analysis/DJI_SDK/dji_executables.zip) and extract the contents to the location of your python file that uses the `thermal_base` package such that the extracted folder `dji_executables` has 2 subfolders named `linux` and `windows` directly inside of it.
+4. Install this package with `python3 -m pip install git+https://github.com/detecttechnologies/thermal_base.git@main`
 
 ## Usage
 Import and use the package as follows:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ logzero >= 1.7.0
 matplotlib >= 3.4.0
 numpy >= 1.19.5
 opencv_python >= 4.5.1.48
+requests >= 2.25.1
 tqdm >= 4.59.0

--- a/thermal_base/thermal_base.py
+++ b/thermal_base/thermal_base.py
@@ -104,8 +104,8 @@ class ThermalImage:
         
         The raw sensor values are obtained using the sample binaries provided in the official Thermal SDK by DJI. 
         The executable file is run and generates a 16 bit unsigned RAW image with Little Endian byte order.
-        Link to DJI Forum post: https://forum.dji.com/forum.php?mod=redirect&goto=findpost&ptid=230321&pid=2389016"""
-
+        Link to DJI Forum post: https://forum.dji.com/forum.php?mod=redirect&goto=findpost&ptid=230321&pid=2389016
+        """
         # read image metadata for the dji camera images
         exif_binary = "exiftool.exe" if "win" in sys.platform else "exiftool"
         meta = sp.Popen(

--- a/thermal_base/thermal_base.py
+++ b/thermal_base/thermal_base.py
@@ -149,7 +149,7 @@ class ThermalImage:
             path_executable = str(Path("./dji_executables", os_name, architecture_name))
             os.environ['LD_LIBRARY_PATH'] = path_executable
             sp.run(["chmod", "u+x", str(Path(path_executable, dji_binary))])
-        else:
+        elif "windows" in os_name:
             path_executable = str(Path("dji_executables", os_name, architecture_name))
         
         # Run executable file dji_irp passing image path and prevent output printing to console. Raw file generated.


### PR DESCRIPTION
Changes made in the thermal_base.py file integrating the DJI Thermal SDK to get the raw sensor output data from it and added the setup instructions to download the DJI SDK executable files.